### PR TITLE
Remove dependency on buffer

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -36,5 +36,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/spacetimehq/spacetime-lang.git"
+  },
+  "engines": {
+    "node" : ">=16.0.0"
   }
 }

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -44,8 +44,7 @@ module.exports = {
             const base64 = "${Buffer.from(wasm).toString('base64')}"
 
             function toUint8Array (s) {
-              if (typeof atob === 'function') return new Uint8Array(atob(s).split('').map(c => c.charCodeAt(0)))
-              return (require('buffer').Buffer).from(s, 'base64')
+              return new Uint8Array(atob(s).split('').map(c => c.charCodeAt(0)))
             }
 
             const wasm = toUint8Array(base64)


### PR DESCRIPTION
Removes dependency on the buffer module.
NextJS includes polyfill for `buffer` by default, so the build already works there, but vanilla CRA webpack config doesn't, which makes it fail there.

`atob` was added in Node v16, so that would be the minimum version that the package will work with.